### PR TITLE
Change format string for parsing week

### DIFF
--- a/src/heath/ledger.py
+++ b/src/heath/ledger.py
@@ -66,9 +66,9 @@ class Ledger:
         next_month_year = self.current_month.year + (next_month > 12)
         next_month = (next_month - 1) % 12 + 1
         temporary_month = Month(next_month_year, next_month)
-        for date, desciption in self.non_working_dates.get(next_month_year, {}).items():
+        for date, description in self.non_working_dates.get(next_month_year, {}).items():
             if date.month == next_month:
-                temporary_month.add_non_working_date(date, desciption)
+                temporary_month.add_non_working_date(date, description)
         return temporary_month.next_work_date
 
     def get_day(self, day_number, month_number=None, year=None) -> Day:
@@ -78,8 +78,8 @@ class Ledger:
     def get_week(self, week_number, year=None) -> CustomTimePeriod:
         year = year or datetime.date.today().year
         week_string = f"{year}-{week_number:02}"
-        monday = datetime.datetime.strptime(f"{week_string}-1", "%Y-%W-%u")
-        sunday = datetime.datetime.strptime(f"{week_string}-7", "%Y-%W-%u")
+        monday = datetime.datetime.strptime(f"{week_string}-1", "%G-%V-%u")
+        sunday = datetime.datetime.strptime(f"{week_string}-7", "%G-%V-%u")
 
         title = f"Vecka {week_number}, {year}"
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -994,6 +994,27 @@ def test_subsequent_months_can_not_start_in_the_middle_of_a_month():
         given_ledger.add_day(given_day)
 
 
+@pytest.mark.parametrize(
+    "given_year, expected_first_date_for_week_1",
+    (
+        (2023, "2023-01-02"),
+        (2024, "2024-01-01"),
+        (2025, "2024-12-30"),
+        (2026, "2025-12-29"),
+        (2027, "2027-01-04"),
+    ),
+)
+def test_get_week_uses_iso_8601_week_numbers(given_year, expected_first_date_for_week_1):
+    # Given a ledger
+    given_ledger = Ledger()
+
+    # When requesting week 1
+    week_1 = given_ledger.get_week(1, given_year)
+
+    # Then the first day of week 1 should be the expected date
+    assert week_1.first_date == date.fromisoformat(expected_first_date_for_week_1)
+
+
 # def test_bad_month_file_raises()
 # def test_bad_year_file_raises()
 # def test_bad_project_file_raises()


### PR DESCRIPTION
To get ISO 8601 weeks %G must be used for years and %V for weeks.

Fixes #50