### PR TITLE
Handle string parsing in tested function

### DIFF
--- a/src/heath/exceptions.py
+++ b/src/heath/exceptions.py
@@ -2,6 +2,10 @@ class HeathError(Exception):
     """Base exception for project"""
 
 
+class TimeError(HeathError):
+    """Base exception for time related errors"""
+
+
 class DayError(HeathError):
     """Base exception for Day"""
 

--- a/src/heath/heath.py
+++ b/src/heath/heath.py
@@ -9,7 +9,7 @@ import click
 import git
 from tabulate import tabulate
 
-from heath import completions, exceptions
+from heath import completions, exceptions, time_utils
 from heath.config import Config
 from heath.day import Day
 from heath.exceptions import ProjectError
@@ -424,7 +424,7 @@ def start(
     new_shift = Shift(ledger.get_project(project), ledger.last_day.date)
     start_datetime = datetime.datetime.combine(
         new_shift.date,
-        datetime.time(*(int(number) for number in start_time.split(":"))),
+        time_utils.parse_time(start_time),
     )
     new_shift.start(start_datetime)
     ledger.last_day.add_shift(new_shift)
@@ -453,9 +453,8 @@ def lunch(ctx, lunch_duration: str, dry_run: bool, verbose: bool):
     folder: LedgerFolder = ctx.obj["FOLDER"]
     verbose |= dry_run
 
-    hours, minutes = map(int, lunch_duration.split(":"))
-    lunch_timedelta = datetime.timedelta(hours=hours, minutes=minutes)
-    ledger.current_shift.lunch(lunch_timedelta)
+    lunch_duration = time_utils.parse_duration(lunch_duration)
+    ledger.current_shift.lunch(lunch_duration)
 
     if not dry_run:
         _write_month_to_disk(
@@ -483,7 +482,7 @@ def stop(ctx, stop_time: str, dry_run: bool, verbose: bool):
 
     stop_datetime = datetime.datetime.combine(
         ledger.last_day.date,
-        datetime.time(*(int(number) for number in stop_time.split(":"))),
+        time_utils.parse_time(stop_time),
     )
     ledger.current_shift.stop(stop_datetime)
 
@@ -518,7 +517,7 @@ def switch(ctx, project: str, start_time: str, dry_run: bool, verbose: bool):
     new_shift = Shift(ledger.get_project(project), ledger.last_day.date)
     switch_datetime = datetime.datetime.combine(
         new_shift.date,
-        datetime.time(*(int(number) for number in start_time.split(":"))),
+        time_utils.parse_time(start_time),
     )
 
     ledger.current_shift.stop(switch_datetime)

--- a/src/heath/time_utils.py
+++ b/src/heath/time_utils.py
@@ -1,4 +1,9 @@
 import datetime
+import re
+
+from heath.exceptions import TimeError
+
+TIME_PATTERN = re.compile(r"(2[0-3])|([0-1]?[0-9])(:[0-5][0-9](:[0-5][0-9])?)?")
 
 
 def pretty_duration(duration: datetime.timedelta, round_seconds: bool = False):
@@ -26,3 +31,23 @@ def pretty_days(days: int) -> str:
 
 def time_to_seconds(time: datetime.time | datetime.datetime):
     return time.hour * 3600 + time.minute * 60 + time.second
+
+
+def parse_time(time_string: str) -> datetime.time:
+    if not TIME_PATTERN.fullmatch(time_string):
+        raise TimeError(f"Could not parse time string '{time_string}'.")
+    return datetime.time(*(int(number) for number in time_string.split(":")))
+
+
+def parse_duration(duration_string: str) -> datetime.timedelta:
+    if not TIME_PATTERN.fullmatch(duration_string):
+        raise TimeError(f"Could not parse duration string '{duration_string}'.")
+
+    return datetime.timedelta(
+        **dict(
+            zip(
+                ("hours", "minutes", "seconds"),
+                (int(number) for number in duration_string.split(":")),
+            )
+        )
+    )

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from heath import time_utils
+from heath.exceptions import TimeError
 
 
 @pytest.mark.parametrize(
@@ -71,3 +72,77 @@ def test_pretty_duration_with_rounding(
     assert (
         time_utils.pretty_duration(given_duration, round_seconds=True) == expected_string
     )
+
+
+@pytest.mark.parametrize(
+    "given_time_string, expected_time",
+    (
+        ("0:00", datetime.time(0)),
+        ("00:00", datetime.time(0)),
+        ("1:23", datetime.time(1, 23)),
+        ("01:23", datetime.time(1, 23)),
+        ("01:23:45", datetime.time(1, 23, 45)),
+        ("8", datetime.time(8)),
+    ),
+)
+def test_parse_time(given_time_string, expected_time):
+    # When parsing user input string
+    parsed_time = time_utils.parse_time(given_time_string)
+
+    # Then the correct time is created
+    assert parsed_time == expected_time
+
+
+@pytest.mark.parametrize(
+    "given_time_string",
+    (
+        "",
+        "000:00",  # Too many leading zeros
+        "1:23:45:67",  # Beyond second precision
+        "24:00",
+        "12:60",
+        "12:34:60",
+        "8:50am",
+        "0_05",  # Real world case that was accepted
+    ),
+)
+def test_parse_time_rejects_bad_time_strings(given_time_string):
+    with pytest.raises(TimeError):
+        time_utils.parse_time(given_time_string)
+
+
+@pytest.mark.parametrize(
+    "given_duration_string, expected_timedelta",
+    (
+        ("0:00", datetime.timedelta()),
+        ("00:00", datetime.timedelta()),
+        ("1:23", datetime.timedelta(hours=1, minutes=23)),
+        ("01:23", datetime.timedelta(hours=1, minutes=23)),
+        ("01:23:45", datetime.timedelta(hours=1, minutes=23, seconds=45)),
+        ("8", datetime.timedelta(hours=8)),
+    ),
+)
+def test_parse_duration(given_duration_string, expected_timedelta):
+    # When parsing user input string
+    parsed_time = time_utils.parse_duration(given_duration_string)
+
+    # Then the correct time is created
+    assert parsed_time == expected_timedelta
+
+
+@pytest.mark.parametrize(
+    "given_duration_string",
+    (
+        "",
+        "000:00",  # Too many leading zeros
+        "1:23:45:67",  # Beyond second precision
+        "24:00",
+        "12:60",
+        "12:34:60",
+        "8:50am",
+        "0_05",  # Real world case that was accepted
+    ),
+)
+def test_parse_duration_rejects_bad_duration_strings(given_duration_string):
+    with pytest.raises(TimeError):
+        time_utils.parse_time(given_duration_string)


### PR DESCRIPTION
Strings for start, stop and lunch was parsed in the cli layer and not by tested functions.

Fixes #52